### PR TITLE
[screensaver.greynetic] 2.3.0

### DIFF
--- a/screensaver.greynetic/addon.xml.in
+++ b/screensaver.greynetic/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.greynetic"
-  version="2.2.1"
+  version="2.3.0"
   name="Greynetic"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required